### PR TITLE
feat: getGeocode componentRestrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ We provide [getGeocode](#getgeocode), [getLatLng](#getlatlng) and [getZipCode](#
 
 It helps you convert address (e.g. "Section 5, Xinyi Road, Xinyi District, Taipei City, Taiwan") into geographic coordinates (e.g. latitude 25.033976 and longitude 121.5645389) or restrict the results to a specific area by [Google Maps Geocoding API](https://developers.google.com/maps/documentation/javascript/geocoding).
 
+In case you want to restrict the results to a specific area you will have to pass the `address` and the `componentRestrictions` matching the [GeocoderComponentRestrictions interface](https://developers.google.com/maps/documentation/javascript/reference/geocoder#GeocoderComponentRestrictions).
+
 ```js
 import { getGeocode } from 'use-places-autocomplete';
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ We provide [getGeocode](#getgeocode), [getLatLng](#getlatlng) and [getZipCode](#
 
 ### getGeocode
 
-It helps you convert address (e.g. "Section 5, Xinyi Road, Xinyi District, Taipei City, Taiwan") into geographic coordinates (e.g. latitude 25.033976 and longitude 121.5645389) by [Google Maps Geocoding API](https://developers.google.com/maps/documentation/javascript/geocoding).
+It helps you convert address (e.g. "Section 5, Xinyi Road, Xinyi District, Taipei City, Taiwan") into geographic coordinates (e.g. latitude 25.033976 and longitude 121.5645389) or restrict the results to a specific area by [Google Maps Geocoding API](https://developers.google.com/maps/documentation/javascript/geocoding).
 
 ```js
 import { getGeocode } from 'use-places-autocomplete';
@@ -332,7 +332,7 @@ getGeocode(parameter)
 
 `getGeocode` is an asynchronous function with the following API:
 
-- `parameter: object` - you must supply one, only one of `address` or `placeId`. It'll be passed as [Geocoding Requests](https://developers.google.com/maps/documentation/javascript/geocoding#GeocodingRequests).
+- `parameter: object` - you must supply one, only one of `address` or `placeId` and optionally `componentRestrictions` object in case you want your results to be restricted to a specific area. It'll be passed as [Geocoding Requests](https://developers.google.com/maps/documentation/javascript/geocoding#GeocodingRequests).
 - `results: array` - an array of objects each contains all the [data](https://developers.google.com/maps/documentation/javascript/geocoding#GeocodingResults).
 - `error: string` - the error status of API response, which has these [values](https://developers.google.com/maps/documentation/javascript/geocoding#GeocodingStatusCodes) (except for "OK").
 

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -4,6 +4,7 @@ describe('getGeocode', () => {
   const data = [{ place_id: '0109' }];
   const error = 'ERROR';
   const geocode = jest.fn();
+  console.warn = jest.fn();
   const setupMaps = (type = 'success'): void => {
     // @ts-ignore
     global.google = {
@@ -44,6 +45,36 @@ describe('getGeocode', () => {
     setupMaps('failure');
     getGeocode({ address: 'Taipei' }).catch((err) => {
       expect(err).toBe(error);
+    });
+  });
+
+  it('should restrict the result to Taiwan and fail', () => {
+    setupMaps('failure');
+    getGeocode({
+      address: 'Belgrade',
+      componentRestrictions: { country: 'TW' },
+    }).catch((err) => {
+      expect(err).toBe(error);
+    });
+  });
+
+  it('should restrict the result to Taiwan and pass', () => {
+    setupMaps();
+    getGeocode({
+      address: 'Taipei',
+      componentRestrictions: { country: 'TW' },
+    }).then((results) => {
+      expect(results).toBe(data);
+    });
+  });
+
+  it('should warn the user for not providing the address or placeId but providing componentRestrictions and pass', () => {
+    setupMaps();
+    getGeocode({
+      componentRestrictions: { country: 'TW', postalCode: '100' },
+    }).then((results) => {
+      expect(console.warn).toBeCalled();
+      expect(results).toBe(data);
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,19 +1,33 @@
 interface GeoArgs {
   address?: string;
   placeId?: string;
+  componentRestrictions?: GeocoderComponentRestrictions;
 }
 type GeocodeResult = google.maps.GeocoderResult;
 type GeoReturn = Promise<GeocodeResult[]>;
+type GeocoderComponentRestrictions = google.maps.GeocoderComponentRestrictions;
 
-export const getGeocode = ({ address, placeId }: GeoArgs): GeoReturn => {
+export const getGeocode = ({
+  address,
+  placeId,
+  componentRestrictions,
+}: GeoArgs): GeoReturn => {
   const geocoder = new window.google.maps.Geocoder();
 
   return new Promise((resolve, reject) => {
-    geocoder.geocode({ address, placeId }, (results, status) => {
-      if (status !== 'OK') reject(status);
-
-      resolve(results);
-    });
+    geocoder.geocode(
+      { address, placeId, componentRestrictions },
+      (results, status) => {
+        if (status !== 'OK') reject(status);
+        if (!address && !placeId && componentRestrictions) {
+          console.warn(
+            'getGeocode: Please provide an address or placeId in order for the componentRestrictions to work properly.'
+          );
+          resolve(results);
+        }
+        resolve(results);
+      }
+    );
   });
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,8 +4,8 @@ interface GeoArgs {
   componentRestrictions?: GeocoderComponentRestrictions;
 }
 type GeocodeResult = google.maps.GeocoderResult;
-type GeoReturn = Promise<GeocodeResult[]>;
 type GeocoderComponentRestrictions = google.maps.GeocoderComponentRestrictions;
+type GeoReturn = Promise<GeocodeResult[]>;
 
 export const getGeocode = ({
   address,
@@ -19,9 +19,9 @@ export const getGeocode = ({
       { address, placeId, componentRestrictions },
       (results, status) => {
         if (status !== 'OK') reject(status);
-        if (!address && !placeId && componentRestrictions) {
+        if (!address && componentRestrictions) {
           console.warn(
-            'getGeocode: Please provide an address or placeId in order for the componentRestrictions to work properly.'
+            'getGeocode: Please provide an address in order for the componentRestrictions to work properly.'
           );
           resolve(results);
         }


### PR DESCRIPTION
## What

Feature: Adding a componentRestrictions option to the getGeocoding method.

## Why

It is an enhancement issue.

## How

Following the google docs interface, I just added the componentRestriction as an optional parameter when calling the getGeocoding which is then passed as a part of [Geocoding Request](https://developers.google.com/maps/documentation/javascript/geocoding#GeocodingRequests)

## Checklist

Have you done all of these things?

- [x] Documentation added
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
