### PR TITLE
getDetails export name has a typo in typings definition

### DIFF
--- a/src/use-places-autocomplete.d.ts
+++ b/src/use-places-autocomplete.d.ts
@@ -283,5 +283,5 @@ declare module "use-places-autocomplete" {
 
   type DetailsResult = Promise<PlaceResult | string>;
 
-  export const getDtails: (args: GetDetailsArgs) => DetailsResult;
+  export const getDetails: (args: GetDetailsArgs) => DetailsResult;
 }


### PR DESCRIPTION
## What

"getDetails" is misspelled as "getDtails" which causes a typescript error.

## Why

Fixes typescript error since 'getDtails' is not the correct name. Currently, using the right name brings up the following error:

```
Module '"use-places-autocomplete"' has no exported member 'getDetails'. Did you mean 'getDtails'?  TS2724
```

## How

Updating the export name from `getDtails` to `getDetails` within the typing definitions found in `src/use-places-autocomplete.d.ts`

## Checklist

Have you done all of these things?

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A] Documentation added
- [N/A] Tests
- [x] Typescript definitions updated
- [x ] Ready to be merged
