### PR TITLE
README: "id" key in "data" array corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,12 @@ const PlacesAutocomplete = () => {
   const renderSuggestions = () =>
     data.map((suggestion) => {
       const {
-        id,
+        place_id,
         structured_formatting: { main_text, secondary_text },
       } = suggestion;
 
       return (
-        <li key={id} onClick={handleSelect(suggestion)}>
+        <li key={place_id} onClick={handleSelect(suggestion)}>
           <strong>{main_text}</strong> <small>{secondary_text}</small>
         </li>
       );
@@ -198,8 +198,8 @@ const PlacesAutocomplete = () => {
       <ComboboxPopover>
         <ComboboxList>
           {status === "OK" &&
-            data.map(({ id, description }) => (
-              <ComboboxOption key={id} value={description} />
+            data.map(({ place_id, description }) => (
+              <ComboboxOption key={place_id} value={description} />
             ))}
         </ComboboxList>
       </ComboboxPopover>


### PR DESCRIPTION
The objects (place suggestions) in the "data" array that is returned in the API response do not have a key "id". It is instead "place_id".

## What

Bug fix to resolve the "Each child in a list should have a unique 'key' prop" warning. This warning occurs in the browser console when either of the examples in the "Create the component" section are run. See attachment below.
![Unique key warning](https://user-images.githubusercontent.com/63400356/98227880-6d9ebe80-1f8a-11eb-9245-3914e4f591b9.png)
.

## Why

To resolve a warning resulting from an object key that cannot be found. The "id" key in the data object no longer exists, Google must have changed it to "place_id" since the examples were written. See attachment for data object in browser console below
![data array and place_id key](https://user-images.githubusercontent.com/63400356/98227978-8effaa80-1f8a-11eb-844e-b63f617be4eb.png)
.

## How

Changes made by editing this README file. This has been discovered (and tested) via implementation on a seperate project. However, I have not seperately forked and tested via the advice in CONTRIBUTING.md since I did not think such a small and simple change warranted this.

## Checklist

Have you done all of these things?

- [x] Documentation added
- [ ] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
