### PR TITLE
fix: resolve bug asRef is null returned getgetPlacePredictions null console and block search places

### DIFF
--- a/src/usePlacesAutocomplete.ts
+++ b/src/usePlacesAutocomplete.ts
@@ -105,7 +105,7 @@ const usePlacesAutocomplete = ({
       }
 
       // @ts-expect-error
-      asRef?.current.getPlacePredictions(
+      asRef.current?.getPlacePredictions(
         { ...requestOptionsRef.current, input: val },
         (data: Suggestion[] | null, status: string) => {
           setSuggestions({ loading: false, status, data: data || [] });

--- a/src/usePlacesAutocomplete.ts
+++ b/src/usePlacesAutocomplete.ts
@@ -105,7 +105,7 @@ const usePlacesAutocomplete = ({
       }
 
       // @ts-expect-error
-      asRef.current.getPlacePredictions(
+      asRef?.current.getPlacePredictions(
         { ...requestOptionsRef.current, input: val },
         (data: Suggestion[] | null, status: string) => {
           setSuggestions({ loading: false, status, data: data || [] });


### PR DESCRIPTION
<!--
  Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

  Before submitting a pull request, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

  Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

  If you're new to contributing to open source projects, you might find this free video course helpful: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github

  Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## What
when you click outside the search console area it returns that getPlacePredictions is null, as asRef.current is null and this bugs the search not returning more resolved

## Why
change allows the search application not to crash

## How

asRef? .current allows the ref to be optional at this point in the code line, avoiding flaws in functionality when the ref is null at the click out

## Checklist

Have you done all of these things?

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
