### PR TITLE
fix anchoring bug in getDetails within README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ const PlacesAutocomplete = () => {
 
 ## Utility Functions
 
-We provide [getGeocode](#getgeocode), [getLatLng](#getlatlng), [getZipCode](#getzipcode) and [getDetails](#getDetails) utils for you to do geocoding and get geographic coordinates when needed.
+We provide [getGeocode](#getgeocode), [getLatLng](#getlatlng), [getZipCode](#getzipcode) and [getDetails](#getdetails) utils for you to do geocoding and get geographic coordinates when needed.
 
 ### getGeocode
 


### PR DESCRIPTION
## What

Fix #762 small anchoring bug (getDetails is currently not linking to the proper section within the docs).

## Why

Improve documentation accessibility

## How

Just fixed a letter casing issue, since the npmjs website is probably case sensitive, which lead to this little bug.
Tested the new change in Dev Tools and it worked properly.

## Checklist

- [x] Documentation added
- [x] Tests
- [ ] TypeScript definitions updated N/A
- [x] Ready to be merged
