### PR TITLE
Add ability to use multiple, separate caches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,19 @@ const methods = usePlacesAutocomplete({
 
 > By the way, the cached data is stored via the [Window.sessionStorage API](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage).
 
+### Custom cache key
+
+You may need to have multiple caches, for example if you use different [place type restrictions](https://developers.google.com/maps/documentation/places/web-service/supported_types#table3_) for different pickers in your app.
+
+```js
+const methods = usePlacesAutocomplete({
+  // Provide a custom cache key
+  cacheKey: "region-restricted",
+});
+```
+
+> Note that usePlacesAutocomplete will prefix this with `upa-`, so the above would become `upa-region-restricted` in sessionStorage.
+
 ## API
 
 ```js
@@ -292,6 +305,7 @@ When use `usePlacesAutocomplete` you can configure the following options via the
 | `callbackName`   | string          |                      | You can provide a callback name to initialize `usePlacesAutocomplete` after Google script is loaded. It's useful when you [load the script asynchronously](#load-the-library).                                          |
 | `debounce`       | number          | `200`                | Number of milliseconds to delay before making a request to Google Maps Places API.                                                                                                                                      |
 | `cache`          | number \| false | `86400` (24 hours)   | Number of seconds to [cache the response data of Google Maps Places API](#cache-data-for-you).                                                                                                                          |
+| `cacheKey`       | string          |                      | Optional cache key so one can use multiple caches if needed.                                                                                                                                                            |
 | `defaultValue`   | string          | `""`                 | Default value for the `input` element.                                                                                                                                                                                  |
 | `initOnMount`    | boolean         | `true`               | Initialize the hook with Google Maps Places API when the component mounts.                                                                                                                                              |
 

--- a/src/__tests__/usePlacesAutocomplete.ts
+++ b/src/__tests__/usePlacesAutocomplete.ts
@@ -237,6 +237,49 @@ describe("usePlacesAutocomplete", () => {
     expect(res.current.suggestions).toEqual(okSuggestions);
   });
 
+  it("should allow custom cache names", () => {
+    const CACHE_KEY_1 = "cache1";
+    const CACHE_KEY_2 = "cache2";
+    jest.setSystemTime(0);
+    // Queue up some cached data
+    const cachedData = [{ place_id: "1119" }];
+    global.google = getMaps("success", cachedData);
+    const res1 = renderHelper({ cache: 10, cacheKey: CACHE_KEY_1 });
+    act(() => {
+      res1.current.setValue("foo");
+      jest.runAllTimers();
+    });
+    // Ensure we're actually getting cached data by resetting getMaps mock
+    global.google = getMaps();
+    act(() => {
+      res1.current.setValue("foo");
+      jest.runAllTimers();
+    });
+    expect(res1.current.suggestions).toEqual({
+      ...okSuggestions,
+      data: cachedData,
+    });
+
+    // Set up a 2nd helper with a different cache key
+    const res2 = renderHelper({ cache: 10, cacheKey: CACHE_KEY_2 });
+    act(() => {
+      res2.current.setValue("foo");
+      jest.runAllTimers();
+    });
+    expect(res2.current.suggestions).toEqual(okSuggestions);
+
+    // Finally, make sure the original cache key still works
+    const res3 = renderHelper({ cache: 10, cacheKey: CACHE_KEY_1 });
+    act(() => {
+      res3.current.setValue("foo");
+      jest.runAllTimers();
+    });
+    expect(res3.current.suggestions).toEqual({
+      ...okSuggestions,
+      data: cachedData,
+    });
+  });
+
   it("should clear cache", () => {
     const cachedData = [{ place_id: "1119" }];
     global.google = getMaps("success", cachedData);

--- a/src/use-places-autocomplete.d.ts
+++ b/src/use-places-autocomplete.d.ts
@@ -9,6 +9,7 @@ declare module "use-places-autocomplete" {
     requestOptions?: RequestOptions;
     debounce?: number;
     cache?: number | false;
+    cacheKey?: string;
     googleMaps?: any;
     callbackName?: string;
     defaultValue?: string;

--- a/src/usePlacesAutocomplete.ts
+++ b/src/usePlacesAutocomplete.ts
@@ -9,6 +9,7 @@ export interface HookArgs {
   requestOptions?: Omit<google.maps.places.AutocompletionRequest, "input">;
   debounce?: number;
   cache?: number | false;
+  cacheKey?: string;
   googleMaps?: any;
   callbackName?: string;
   defaultValue?: string;
@@ -39,12 +40,12 @@ interface HookReturn {
 
 export const loadApiErr =
   "💡 use-places-autocomplete: Google Maps Places API library must be loaded. See: https://github.com/wellyshen/use-places-autocomplete#load-the-library";
-const cacheKey = "upa";
 
 const usePlacesAutocomplete = ({
   requestOptions,
   debounce = 200,
   cache = 24 * 60 * 60,
+  cacheKey,
   googleMaps,
   callbackName,
   defaultValue = "",
@@ -60,6 +61,7 @@ const usePlacesAutocomplete = ({
   const asRef = useRef(null);
   const requestOptionsRef = useLatest(requestOptions);
   const googleMapsRef = useLatest(googleMaps);
+  const upaCacheKey = cacheKey ? `upa-${cacheKey}` : "upa";
 
   const init = useCallback(() => {
     if (asRef.current) return;
@@ -83,7 +85,7 @@ const usePlacesAutocomplete = ({
 
   const clearCache = useCallback(() => {
     try {
-      sessionStorage.removeItem(cacheKey);
+      sessionStorage.removeItem(upaCacheKey);
     } catch (error) {
       // Skip exception
     }
@@ -102,7 +104,7 @@ const usePlacesAutocomplete = ({
         {};
 
       try {
-        cachedData = JSON.parse(sessionStorage.getItem(cacheKey) || "{}");
+        cachedData = JSON.parse(sessionStorage.getItem(upaCacheKey) || "{}");
       } catch (error) {
         // Skip exception
       }
@@ -140,7 +142,7 @@ const usePlacesAutocomplete = ({
             };
 
             try {
-              sessionStorage.setItem(cacheKey, JSON.stringify(cachedData));
+              sessionStorage.setItem(upaCacheKey, JSON.stringify(cachedData));
             } catch (error) {
               // Skip exception
             }


### PR DESCRIPTION
## What

Add ability to use multiple, separate caches

## Why

Suppose in one part of an app we want to limit results to `(regions)` (as an example: no specific addresses), but in another we're ok with having all results (including addresses). Using the same cache across these two pickers could result in an address being returned and selected for the first component.

## How

By providing an optional `cacheKey`, we can use different caches for the different result sets.

## Checklist

- [x] Documentation added
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
