### PR TITLE
Replace `@types/googlemaps` with `@types/google.maps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ $ yarn add use-places-autocomplete
 $ npm install --save use-places-autocomplete
 ```
 
-When working with TypeScript you need to install the [@types/googlemaps](https://www.npmjs.com/package/@types/googlemaps) as a `devDependencies`.
+When working with TypeScript you need to install the [@types/google.maps](https://www.npmjs.com/package/@types/google.maps) as a `devDependencies`.
 
 ```sh
-$ yarn add --dev @types/googlemaps
+$ yarn add --dev @types/google.maps
 # or
-$ npm install --save-dev @types/googlemaps
+$ npm install --save-dev @types/google.maps
 ```
 
 ## Getting Started

--- a/app/package.json
+++ b/app/package.json
@@ -39,7 +39,7 @@
     "use-places-autocomplete": "latest"
   },
   "devDependencies": {
-    "@types/googlemaps": "^3.43.3",
+    "@types/google.maps": "^3.49.2",
     "eslint-config-welly": "^1.13.0",
     "npm-run-all": "^4.1.5",
     "postcss-scss": "^4.0.4",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1800,10 +1800,10 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/googlemaps@^3.43.3":
-  version "3.43.3"
-  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.43.3.tgz#70cf962154a160fe78bcd69d6ccc296dd9175b1f"
-  integrity sha512-ZWNoz/O8MPEpiajvj7QiqCY8tTLFNqNZ/a+s+zTV58wFVNAvvqV4bdGfnsjTb5Cs4V6wEsLrX8XRhmnyYJ2Tdg==
+"@types/google.maps@^3.49.2":
+  version "3.49.2"
+  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.49.2.tgz#9640491ec3aa96c9de1466894117ce81c02588df"
+  integrity sha512-ZO1qWciukqED9qcUNW7OaPXWnTlT+tO3WcYkmudZyQW2BqD7TlMFRrdqSCoqfwKhERCwBA5A/YZt/g5A3BqgLQ==
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
@@ -7428,7 +7428,7 @@ react-app-polyfill@^3.0.0:
     regenerator-runtime "^0.13.9"
     whatwg-fetch "^3.6.2"
 
-react-cool-onclickoutside@^1.7.0:
+react-cool-onclickoutside@latest:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/react-cool-onclickoutside/-/react-cool-onclickoutside-1.7.0.tgz#abc844e14852220fe15f81d7ef44976d15cd9980"
   integrity sha512-HVZK2155Unee+enpoHKyYP2UdQK69thw90XAOUCjvJBcgRSgfRPgWWt/W1dYzoGp3+nleAa8SJxF1d4FMA4Qmw==
@@ -8877,10 +8877,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-use-places-autocomplete@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/use-places-autocomplete/-/use-places-autocomplete-2.0.0.tgz#868454252f52f281b64d637f44283fde0cc06c84"
-  integrity sha512-MO1MBaaOW+tK8iatf9CPBbjwvtoa7lCNVamAkne9pTP6YcKmbQa/uLZa5nLqR5E8WulvLcC/R4Skuw1joVz45Q==
+use-places-autocomplete@latest:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/use-places-autocomplete/-/use-places-autocomplete-3.0.0.tgz#1ef709e27212b4cc0d3db17b13039dc9a9cefd48"
+  integrity sha512-goow+G/crCRQ1WMVw6RMiBfH/7VQF38dF6ccS4YBzr49qEuYNN9PzaBEdUGvi5S4CMnXIqfT+zDLsy/u9kqy4Q==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@rollup/plugin-replace": "^3.0.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^7.0.2",
-    "@types/googlemaps": "^3.43.3",
+    "@types/google.maps": "^3.49.2",
     "@types/jest": "^27.4.0",
     "@types/lodash.debounce": "^4.0.6",
     "@types/react": "^17.0.38",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ type GeoArgs = google.maps.GeocoderRequest;
 
 type GeocodeResult = google.maps.GeocoderResult;
 
-type GeoReturn = Promise<GeocodeResult[]>;
+type GeoReturn = Promise<GeocodeResult[] | null>;
 
 export const geocodeErr =
   "💡 use-places-autocomplete: Please provide an address when using getGeocode() with the componentRestrictions.";
@@ -48,7 +48,7 @@ export const getZipCode = (
 
 type GetDetailsArgs = google.maps.places.PlaceDetailsRequest;
 
-type DetailsResult = Promise<google.maps.places.PlaceResult | string>;
+type DetailsResult = Promise<google.maps.places.PlaceResult | null>;
 
 export const getDetailsErr =
   "💡 use-places-autocomplete: Please provide a place Id when using getDetails() either as a string or as part of an Autocomplete Prediction.";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1458,10 +1458,10 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/googlemaps@^3.43.3":
-  version "3.43.3"
-  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.43.3.tgz#70cf962154a160fe78bcd69d6ccc296dd9175b1f"
-  integrity sha512-ZWNoz/O8MPEpiajvj7QiqCY8tTLFNqNZ/a+s+zTV58wFVNAvvqV4bdGfnsjTb5Cs4V6wEsLrX8XRhmnyYJ2Tdg==
+"@types/google.maps@^3.49.2":
+  version "3.49.2"
+  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.49.2.tgz#9640491ec3aa96c9de1466894117ce81c02588df"
+  integrity sha512-ZO1qWciukqED9qcUNW7OaPXWnTlT+tO3WcYkmudZyQW2BqD7TlMFRrdqSCoqfwKhERCwBA5A/YZt/g5A3BqgLQ==
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"


### PR DESCRIPTION
The [@types/googlemaps](https://www.npmjs.com/package/@types/googlemaps) package is deprecated. So, let's replace it with [@types/google.maps](https://www.npmjs.com/package/@types/google.maps). ( #1018 )