### PR TITLE
Fix advice for retrieving info with `getDetails`

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ const PlacesAutocomplete = () => {
 - `placeResult: object | null` - [the details](https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult) about the specific place your queried.
 - `error: any` - an exception.
 
-> ⚠️ warning, you are billed based on how much information you retrieve, So it is advised that you retrieve just what you.
+> ⚠️ warning, you are billed based on how much information you retrieve, So it is advised that you retrieve only what you need.
 
 ## Articles / Blog Posts
 


### PR DESCRIPTION
## What

It seems that that line was missing a word at the end, this fixes it.

## Why

So that the phrase makes sense

## How

Fixed the phrase in the README.md.

## Checklist

Have you done all of these things?

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
- [ ] Tests N/A
- [ ] TypeScript definitions updated N/A
- [x] Ready to be merged
